### PR TITLE
Fix HTML-escaped > in Auth.vue

### DIFF
--- a/authentication/email/src/pages/Auth.vue
+++ b/authentication/email/src/pages/Auth.vue
@@ -25,7 +25,7 @@
         color="primary"
         data-cy="password"
         label="PASSWORD"
-        :rules="[val =&gt; !!val || '*Field is required']"
+        :rules="[val => !!val || '*Field is required']"
         :type="isPwd ? 'password' : 'text'"
         @keyup.enter="onSubmit();"
       >


### PR DESCRIPTION
One of the form validation rules was `[val =&gt; !!val || '*Field is required']` - the HTML escaping of the greater-than sign breaks the arrow function.